### PR TITLE
Added node.indexExists in apoc.schema available procs

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/indexes/schema-index-operations.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/indexes/schema-index-operations.adoc
@@ -14,6 +14,7 @@ include::example$generated-documentation/apoc.schema.nodes.adoc[]
 include::example$generated-documentation/apoc.schema.relationships.adoc[]
 include::example$generated-documentation/apoc.schema.node.constraintExists.adoc[]
 include::example$generated-documentation/apoc.schema.relationship.constraintExists.adoc[]
+include::example$generated-documentation/apoc.schema.node.indexExists.adoc[]
 |===
 
 [source,cypher]


### PR DESCRIPTION
An example for this function already exists, but it is not listed in the list at the top.

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  -
  -
  -
